### PR TITLE
Add lowPriority to ExecutionPolicy type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,9 @@ import pkg from "../package.json"
 const axios = xior.create();
 
 export type ExecutionPolicy = {
-  ttl?: number
   executionTimeout?: number
+  lowPriority?: boolean
+  ttl?: number
 }
 export type S3Config = {
   accessId: string


### PR DESCRIPTION
Add `lowPriority?: boolean` to `ExecutionPolicy` type, ordered alphabetically. Fixes TypeScript error (`'lowPriority' does not exist`) when using `lowPriority` in `policy` with exported types (e.g., `EndpointInputPayload`), aligning with API docs: https://docs.runpod.io/serverless/endpoints/send-requests#java-script