### PR TITLE
Update SDK version to 1.1.2 and hardcode in user agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runpod-sdk",
-  "version": "1.0.7",
+  "version": "1.1.2",
   "description": "JavaScript SDK for Runpod",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import xior, { XiorResponse as AxiosResponse } from "xior"
 import { curry, clamp, isNil } from "ramda"
-import pkg from "../package.json"
 
 const axios = xior.create();
 
@@ -65,7 +64,7 @@ export type SdkOptions = {
 }
 
 function getUserAgent() {
-  const sdkVersion = pkg.version;
+  const sdkVersion = "1.1.2";
 
   let environmentInfo = 'Unknown Environment';
 


### PR DESCRIPTION
Bumped the package version to 1.1.2 in package.json and replaced dynamic import of the version in getUserAgent with a hardcoded string. This simplifies version handling and removes the dependency on importing package.json at runtime.